### PR TITLE
Source rendering (QA)

### DIFF
--- a/api/contextqa/models/schemas.py
+++ b/api/contextqa/models/schemas.py
@@ -19,7 +19,7 @@ class SourceFormat(str, Enum):
 class Source(BaseModel):
     title: str
     format_: Annotated[SourceFormat, Field(alias="format")]
-    content: str | dict
+    content: str | list
 
 
 class LLMResult(BaseModel):

--- a/api/contextqa/utils/sources.py
+++ b/api/contextqa/utils/sources.py
@@ -117,30 +117,45 @@ def build_sources(sources: list[Document]) -> list[Source]:
         sources transformed into a proper format depending the file type
     """
     result = []
+    processed_sources = set()
+
     for source in sources:
         name = source.metadata.pop("source")
         source_name = name.split(settings.tmp_separator)[-1]
         extension = name.split(".")[-1]
+
         match extension:
             case SourceFormat.PDF:
                 page_number = source.metadata.get("page")
                 path = Path(name)
-                pdf = fitz.open(str(path))
-                page = pdf[page_number]
-                img_bytes = page.get_pixmap().tobytes()
-                base64_img = base64.b64encode(img_bytes)
-                source = Source(title=f"{path.name} - Page {page_number}", format=SourceFormat.PDF, content=base64_img)
+                title = f"{path.name} - Page {page_number}"
+                if title not in processed_sources:
+                    pdf = fitz.open(str(path))
+                    page = pdf[page_number]
+                    img_bytes = page.get_pixmap().tobytes()
+                    base64_img = base64.b64encode(img_bytes).decode().replace('"', '\\"')
+                    format_ = SourceFormat.PDF
+                    content = base64_img
             case SourceFormat.TXT:
                 idx = source.metadata.get("idx")
-                source = Source(
-                    title=f"{source_name} - Segment {idx}", format=SourceFormat.TXT, content=source.page_content
-                )
+                title = f"{source_name} - Segment {idx}"
+                if title not in processed_sources:
+                    format_ = SourceFormat.TXT
+                    content = source.page_content
             case SourceFormat.CSV:
                 row = source.metadata.get("row")
-                data = {}
-                for cell in source.page_content.split("\n"):
-                    key, value = cell.split(":", 1)
-                    data[key] = value.strip()
-                    source = Source(title=f"{source_name} - Row {row}", format=SourceFormat.CSV, content=data)
-        result.append(source.model_dump())
+                title = f"{source_name} - Row {row}"
+                format_ = SourceFormat.CSV
+                if title not in processed_sources:
+                    data = {}
+                    for cell in source.page_content.split("\n"):
+                        key, value = cell.split(":", 1)
+                        data[key] = value.strip()
+                    content = [data]
+
+        if title not in processed_sources:
+            source_data = Source(title=title, format=format_, content=content)
+            result.append(source_data.model_dump())
+            processed_sources.add(title)
+
     return result

--- a/client/src/components/ChatBox.vue
+++ b/client/src/components/ChatBox.vue
@@ -282,6 +282,7 @@ export default {
             if (token.includes("<sources>")) {
               finished = true;
               this.latestSources = token.split("<sources>")[1];
+              this.$store.dispatch("setLatestSources", this.latestSources);
             }
             if (!finished) this.answer += token;
           }

--- a/client/src/components/SourcesBox.vue
+++ b/client/src/components/SourcesBox.vue
@@ -50,8 +50,10 @@ export default {
     };
   },
   mounted() {
+    const sources =
+      this.dialogRef.data.sources || this.$store.state.latestSources;
     try {
-      this.data = JSON.parse(this.dialogRef.data.sources);
+      this.data = JSON.parse(sources);
     } catch (e) {
       console.log(e);
     }

--- a/client/src/components/SourcesBox.vue
+++ b/client/src/components/SourcesBox.vue
@@ -23,12 +23,13 @@
             :header="name"
           ></Column>
         </DataTable>
-        <Image
-          class="m-0"
-          :src="`data:image/jpg;base64,${source.content}`"
-          v-else
-          preview
-        />
+        <div v-else class="text-center">
+          <Image
+            class="m-0"
+            :src="`data:image/jpg;base64,${source.content}`"
+            preview
+          />
+        </div>
       </template>
     </Card>
   </div>

--- a/client/src/components/SourcesBox.vue
+++ b/client/src/components/SourcesBox.vue
@@ -1,0 +1,63 @@
+<template>
+  <div class="w-full">
+    <Card
+      :key="i"
+      v-for="(source, i) in data"
+      class="mx-0 my-5"
+      :pt="{
+        content: { class: 'mx-0' },
+      }"
+    >
+      <template #title>
+        {{ source.title }}
+      </template>
+      <template #content>
+        <p v-if="source.format_ == 'txt'">
+          {{ source.content }}
+        </p>
+        <DataTable v-else-if="source.format_ == 'csv'" :value="source.content">
+          <Column
+            v-for="(name, i) in Object.keys(source.content[0])"
+            :key="i"
+            :field="name"
+            :header="name"
+          ></Column>
+        </DataTable>
+        <Image
+          class="m-0"
+          :src="`data:image/jpg;base64,${source.content}`"
+          v-else
+          preview
+        />
+      </template>
+    </Card>
+  </div>
+</template>
+
+<script>
+import Card from "primevue/card";
+import DataTable from "primevue/datatable";
+import Column from "primevue/column";
+import Image from "primevue/image";
+
+export default {
+  inject: ["dialogRef"],
+  name: "SourcesBox",
+  components: { Card, DataTable, Column, Image },
+  data() {
+    return {
+      data: [],
+    };
+  },
+  mounted() {
+    try {
+      this.data = JSON.parse(this.dialogRef.data.sources);
+    } catch (e) {
+      console.log(e);
+    }
+  },
+};
+</script>
+
+<style>
+</style>

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -5,6 +5,7 @@ import store from './store'
 
 
 import PrimeVue from 'primevue/config';
+import DialogService from 'primevue/dialogservice';
 import ToastService from 'primevue/toastservice';
 import ConfirmationService from 'primevue/confirmationservice';
 
@@ -16,4 +17,4 @@ import '/node_modules/primeflex/primeflex.css'
 
 export const app = createApp(App);
 
-app.use(PrimeVue).use(ToastService).use(ConfirmationService).use(store).use(router).mount('#app');
+app.use(PrimeVue).use(ToastService).use(ConfirmationService).use(store).use(DialogService).use(router).mount('#app');

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -9,7 +9,8 @@ export default createStore({
         lastDocumentMessageText: '',
         lastChatMessageText: '',
         vectorStore: '',
-        internetEnabled: false
+        internetEnabled: false,
+        latestSources: ''
     },
     mutations: {
         updateApiParams(state, payload) {
@@ -44,6 +45,9 @@ export default createStore({
         },
         updateInternetAccess(state, payload) {
             state.internetEnabled = payload
+        },
+        updateSources(state, payload) {
+            state.latestSources = payload
         }
     },
     actions: {
@@ -67,6 +71,9 @@ export default createStore({
         },
         setInternetAccess({ commit }, payload) {
             commit('updateInternetAccess', payload);
+        },
+        setLatestSources({ commit }, payload) {
+            commit('updateSources', payload);
         }
     }
 });


### PR DESCRIPTION
Now users can check the sources used to answer their questions when using the **QA** feature.
### Example
#### Question and answer
![image](https://github.com/zaldivards/ContextQA/assets/32210667/a50edc3b-8d02-4ca5-a07b-86f4ed25d661)
 #### Sources used to answer
![image](https://github.com/zaldivards/ContextQA/assets/32210667/4045a801-279f-4611-acc5-62526cab50f4)
